### PR TITLE
Implemented documentation automatic generation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,30 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - '**.js'
+      - 'package.json'
+      - 'docs/**'
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: element
+        template: docs/template.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,21 +7,19 @@ on:
     paths:
       - '**.js'
       - 'example/index.html'
+      - 'package.json'
 env:
   AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_KEY_SECRET: ${{ secrets.AWS_KEY_SECRET }}
   BUCKET: ${{ secrets.S3_PUBLIC_BUCKET }}
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
-    - uses: paambaati/codeclimate-action@v2.4.0
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.REPORTER_ID }}
-      with:
-        coverageCommand: npm test
+    - uses: Test
+      run: npm test
     - name: Upload files to S3 bucket
       uses: kaskadi/action-s3cp@master

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,33 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/kaskadi-authenticator)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/kaskadi-authenticator?color=blue)
+
+[![](https://img.shields.io/badge/live-example-orange)](https://cdn.klimapartner.net/modules/%40kaskadi/kaskadi-authenticator/example/index.html)
+
+**GitHub Actions workflows status**
+
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-authenticator/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-authenticator/actions?query=workflow%3Abuild)
+[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-authenticator/build-on-firefox?label=firefox&logo=Mozilla%20Firefox&logoColor=white)](https://github.com/kaskadi/kaskadi-authenticator/actions?query=workflow%3Abuild-on-firefox)
+[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-authenticator/build-on-chrome?label=chrome&logo=Google%20Chrome&logoColor=white)](https://github.com/kaskadi/kaskadi-authenticator/actions?query=workflow%3Abuild-on-chrome)
+[![Publish status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-authenticator/publish?label=publish&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-authenticator/actions?query=workflow%3Apublish)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-authenticator/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/kaskadi-authenticator/actions?query=workflow%3Agenerate-docs)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-authenticator?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-authenticator)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-authenticator?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-authenticator)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-authenticator?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-authenticator)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-authenticator?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-authenticator/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/kaskadi-authenticator.js
+++ b/kaskadi-authenticator.js
@@ -1,6 +1,21 @@
 /* eslint-env browser, mocha */
 import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
 
+/**
+ * Element offering a login interface to Kaskadi's project backend.
+ *
+ * This consists of 2 fields for respectively username and password. It then send a request to the backend and dispatches a new event with the login attempt response.
+ *
+ * @module kaskadi-authenticator
+ *
+ * @param {string} lang - element's language
+ * @param {Event} onlogin - after attempting to log in, the event will dispatch a `login` event containing in its `details` the response payload
+ *
+ * @example
+ *
+ * <kaskadi-authenticator lang="en"></kaskadi-authenticator>
+ */
+
 class KaskadiAuthenticator extends KaskadiElement {
   constructor () {
     super()
@@ -25,7 +40,7 @@ class KaskadiAuthenticator extends KaskadiElement {
     }
     await fetch('https://api.klimapartner.net/auth/login', init)
       .then(res => res.json())
-      .then(json => new CustomEvent('login', { detail: json }))
+      .then(json => new CustomEvent('login', { details: json }))
       .then(event => this.dispatchEvent(event))
   }
 

--- a/kaskadi-authenticator.js
+++ b/kaskadi-authenticator.js
@@ -1,7 +1,7 @@
 /* eslint-env browser, mocha */
-import { html, LitElement } from 'https://cdn.klimapartner.net/modules/lit-element/lit-element.js'
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
 
-class KaskadiAuthenticator extends LitElement {
+class KaskadiAuthenticator extends KaskadiElement {
   constructor () {
     super()
     this.lang = 'en'
@@ -23,12 +23,10 @@ class KaskadiAuthenticator extends LitElement {
       method: 'POST',
       body: JSON.stringify(fetchBody)
     }
-    const res = await fetch('https://97j2nzedqk.execute-api.eu-central-1.amazonaws.com/prod/auth/login', init)
-    const json = await res.json()
-    const event = new CustomEvent('login', {
-      detail: json
-    })
-    this.dispatchEvent(event)
+    await fetch('https://api.klimapartner.net/auth/login', init)
+      .then(res => res.json())
+      .then(json => new CustomEvent('login', { detail: json }))
+      .then(event => this.dispatchEvent(event))
   }
 
   render () {


### PR DESCRIPTION
**Changes description**
Implemented documentation automatic generation using the GitHub action `action-generate-docs` inside of a new `generate-docs` workflow. This uses a template located under `docs/template.md`.

**New features**
- _`generate-docs` workflow:_ workflow running on push (same triggers as `publish`) that generates the element documentation automatically using `action-generate-docs`
- _documentation template:_ added template for documentation under `docs/template.md`

**Updated features**
- _`template-kaskadi-element.js`:_ added JSDoc comments for documentation